### PR TITLE
Fixes issue #1 : Fixed Bug in UpsolveContestProblemActivity.kt

### DIFF
--- a/app/src/main/java/com/example/cfbuddy/UpsolveContestProblemsActivity.kt
+++ b/app/src/main/java/com/example/cfbuddy/UpsolveContestProblemsActivity.kt
@@ -62,7 +62,6 @@ class UpsolveContestProblemsActivity : AppCompatActivity() {
                             break
                         } else if (result.points == 0 && result.rejectedAttemptCount != 0) {
                             status = "Unsolved"
-                            break
                         }
                     }
 


### PR DESCRIPTION
# Issue #1 Fixed Bug in UpsolveContestProblemActivity.kt

Removed the break statement from unsolved block because it waas breaking if there was wrong submission during problem not checking for more rows in the api where sometimes status could be accepted